### PR TITLE
Add condition to ecosystem CI workflow

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'quarkusbot' || github.actor == 'quarkiversebot'
     uses: quarkiverse/.github/.github/workflows/quarkus-ecosystem-ci.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Restrict ecosystem CI to workflow_dispatch and quarkusbot.

  - See https://github.com/quarkiverse/quarkiverse-devops/issues/443